### PR TITLE
Use `~LVN` instead of `~SWIFTUI`

### DIFF
--- a/syntaxes/elixir-neex.json
+++ b/syntaxes/elixir-neex.json
@@ -5,7 +5,7 @@
       {
         "comment": "HEEx sigil with heredoc (double quotes)",
         "name": "text.swiftui.neex",
-        "begin": "\\s?(~SWIFTUI\"\"\")$",
+        "begin": "\\s?(~LVN\"\"\")$",
         "beginCaptures": {
           "0": {
             "name": "string.quoted.double.heredoc.elixir"
@@ -26,7 +26,7 @@
       {
         "comment": "HEEx sigil with double quotes",
         "name": "text.swiftui.neex",
-        "begin": "~SWIFTUI\\\"",
+        "begin": "~LVN\\\"",
         "beginCaptures": {
           "0": {
             "name": "string.quoted.double.heredoc.elixir"
@@ -47,7 +47,7 @@
       {
         "comment": "HEEx sigil with square brackets",
         "name": "text.swiftui.neex",
-        "begin": "~SWIFTUI\\[",
+        "begin": "~LVN\\[",
         "beginCaptures": {
           "0": {
             "name": "string.quoted.double.heredoc.elixir"
@@ -68,7 +68,7 @@
       {
         "comment": "HEEx sigil with parentheses",
         "name": "text.swiftui.neex",
-        "begin": "~SWIFTUI\\(",
+        "begin": "~LVN\\(",
         "beginCaptures": {
           "0": {
             "name": "string.quoted.double.heredoc.elixir"
@@ -89,7 +89,7 @@
       {
         "comment": "HEEx sigil with curly brackets",
         "name": "text.swiftui.neex",
-        "begin": "~SWIFTUI\\{",
+        "begin": "~LVN\\{",
         "beginCaptures": {
           "0": {
             "name": "string.quoted.double.heredoc.elixir"


### PR DESCRIPTION
The `~SWIFTUI` sigil was renamed to `~LVN`.