### PR TITLE
Add syntax highlighting for the `style` attribute

### DIFF
--- a/syntaxes/neex.json
+++ b/syntaxes/neex.json
@@ -345,7 +345,27 @@
                 "name": "punctuation.definition.string.begin.html"
               }
             },
-            "end": "(~s)?\"",
+            "end": "\"",
+            "endCaptures": {
+              "0": {
+                "name": "punctuation.definition.string.end.html"
+              }
+            },
+            "name": "string.quoted.double.html",
+            "patterns": [
+              {
+                "include": "source.swift"
+              }
+            ]
+          },
+          {
+            "begin": "(~s)?'",
+            "beginCaptures": {
+              "0": {
+                "name": "punctuation.definition.string.begin.html"
+              }
+            },
+            "end": "'",
             "endCaptures": {
               "0": {
                 "name": "punctuation.definition.string.end.html"

--- a/syntaxes/neex.json
+++ b/syntaxes/neex.json
@@ -280,7 +280,36 @@
             "include": "#interpolation"
           },
           {
+            "include": "#style-attribute"
+          },
+          {
             "include": "#attribute"
+          }
+        ]
+      },
+      "style-attribute": {
+        "begin": "(style)(=)(\"|')",
+        "beginCaptures": {
+          "1": {
+            "name": "entity.other.attribute-name.html"
+          },
+          "2": {
+            "name": "punctuation.separator.key-value.html"
+          },
+          "3": {
+            "name": "punctuation.definition.string.begin.html"
+          }
+        },
+        "end": "(\"|')",
+        "endCaptures": {
+          "0": {
+            "name": "punctuation.definition.string.end.html"
+          }
+        },
+        "name": "meta.attribute.style",
+        "patterns": [
+          {
+            "include": "source.swift"
           }
         ]
       },

--- a/syntaxes/neex.json
+++ b/syntaxes/neex.json
@@ -288,28 +288,95 @@
         ]
       },
       "style-attribute": {
-        "begin": "(style)(=)(\"|')",
+        "begin": "style",
         "beginCaptures": {
-          "1": {
-            "name": "entity.other.attribute-name.html"
-          },
-          "2": {
-            "name": "punctuation.separator.key-value.html"
-          },
-          "3": {
-            "name": "punctuation.definition.string.begin.html"
-          }
-        },
-        "end": "(\"|')",
-        "endCaptures": {
           "0": {
-            "name": "punctuation.definition.string.end.html"
+            "name": "entity.other.attribute-name.html"
           }
         },
+        "end": "(?=\\s*+[^=\\s])",
         "name": "meta.attribute.style",
         "patterns": [
           {
-            "include": "source.swift"
+            "begin": "=",
+            "beginCaptures": {
+              "0": {
+                "name": "punctuation.separator.key-value.html"
+              }
+            },
+            "end": "(?<=[^\\s=])(?!\\s*=)|(?=/?>)",
+            "patterns": [
+              {
+                "begin": "\\{",
+                "name": "source.elixir.embedded",
+                "beginCaptures": {
+                  "0": {
+                    "name": "punctuation.section.embedded.begin.heex"
+                  }
+                },
+                "end": "\\}",
+                "endCaptures": {
+                  "0": {
+                    "name": "punctuation.section.embedded.end.heex"
+                  }
+                },
+                "patterns": [
+                  {
+                    "include": "#style-attribute-value"
+                  },
+                  {
+                    "include": "source.elixir"
+                  }
+                ]
+              },
+              {
+                "include": "#style-attribute-value"
+              }
+            ]
+          }
+        ]
+      },
+      "style-attribute-value": {
+        "patterns": [
+          {
+            "begin": "(~s)?\"",
+            "beginCaptures": {
+              "0": {
+                "name": "punctuation.definition.string.begin.html"
+              }
+            },
+            "end": "(~s)?\"",
+            "endCaptures": {
+              "0": {
+                "name": "punctuation.definition.string.end.html"
+              }
+            },
+            "name": "string.quoted.double.html",
+            "patterns": [
+              {
+                "include": "source.swift"
+              }
+            ]
+          },
+          {
+            "begin": "~s\\[",
+            "beginCaptures": {
+              "0": {
+                "name": "punctuation.section.list.begin.elixir"
+              }
+            },
+            "end": "\\]",
+            "endCaptures": {
+              "0": {
+                "name": "punctuation.section.list.end.elixir"
+              }
+            },
+            "name": "string.quoted.single.html",
+            "patterns": [
+              {
+                "include": "source.swift"
+              }
+            ]
           }
         ]
       },


### PR DESCRIPTION
This adds syntax highlighting for the `style` attribute to `.neex` templates.

<img width="527" alt="Screenshot 2024-05-16 at 3 47 59 PM" src="https://github.com/liveview-native/liveview-native-vscode/assets/13581484/a00b1393-43d3-408a-aa0c-e5ef265d7d47">
